### PR TITLE
fix null value in markdown.lua

### DIFF
--- a/lua/notion/markdown.lua
+++ b/lua/notion/markdown.lua
@@ -180,7 +180,9 @@ M.page = function(data, id, _, open)
             local markdown = ""
             if richText == nil then return "" end
             for _, value in ipairs(richText) do
-                local text = value.text.content
+               
+                local text = value.text and value.text.content or ""
+
                 local annotations = value.annotations
                 if annotations.bold then
                     text = "**" .. text .. "**"


### PR DESCRIPTION
fixing next error in content validation

...ocal/share/nvim/lazy/notion.nvim/lua/notion/markdown.lua:183: attempt to index field 'text' (a nil value)