### PR TITLE
Fixes vim-plug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ use {
 
 [**vim-plug**](https://github.com/junegunn)
 ```lua
-Plug 'Al0den/tester.nvim'
+" Dependencies:
+Plug 'nvim-telescope/telescope.nvim'
+Plug 'nvim-lua/plenary.nvim'
+
+" Actual Plugin:
+Plug 'Al0den/notion.nvim' 
 
 lua << END
 require"notion".setup()


### PR DESCRIPTION
I believe `'Al0den/tester.nvim'` was there on accident.

Note that Vim-Plug [does not offer managing dependencies automatically](https://github.com/junegunn/vim-plug/wiki/faq#managing-dependencies), thus dependencies must be listed explicitly.